### PR TITLE
Inca and Poly special terrian city flavor fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -1097,7 +1097,15 @@ int PathCost(CvAStarNode* parent, CvAStarNode* node, int data, const void* point
 			// We want to discourage AIs and automated units from exhausting their movement on a mountain, but if the unit is manually controlled by the human, let them do what they want.
 			if (!pCacheData->isHuman() || pCacheData->IsAutomated())
 			{
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+				if (pUnit->canFound(pToPlot))
+				{
+					iCost += GC.getINFLUENCE_HILL_COST();
+				}
+				else iCost += PATH_END_TURN_MOUNTAIN_WEIGHT;
+#else
 				iCost += PATH_END_TURN_MOUNTAIN_WEIGHT;
+#endif
 			}
 		}
 

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -4060,6 +4060,10 @@ int TradeRouteLandPathCost(CvAStarNode* parent, CvAStarNode* node, int data, con
 		// Any land unit may travel over a mountain with a pass
 		bMountain = false;
 	}
+	if (bMountain && pToPlot->isCity())
+	{
+		bMountain = false;
+	}
 
 	if (pToPlot->isImpassable() || bMountain)
 #else

--- a/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -22689,7 +22689,7 @@ void CvPlayer::doResearch()
 		}
 		else
 		{
-			iOverflowResearch = (getOverflowResearchTimes100() * calculateResearchModifier(eCurrentTech)) / 100;
+			iOverflowResearch = (getOverflowResearchTimes100()/100) * calculateResearchModifier(eCurrentTech);
 			setOverflowResearch(0);
 			if(GET_TEAM(getTeam()).GetTeamTechs())
 			{

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -346,6 +346,13 @@ int CvCitySiteEvaluator::PlotFoundValue(CvPlot* pPlot, CvPlayer* pPlayer, YieldT
 	int iClosestCityOfMine = 999;
 	int iClosestEnemyCity = 999;
 
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+	int iIncaMountainCityValue = 500;
+#endif
+#ifdef MOD_TRAITS_CAN_FOUND_COAST_CITY
+	int iPolyCoastCityValue = 500;
+#endif
+
 	int iCapitalArea = NULL;
 
 	bool bIsInca = false;
@@ -661,6 +668,20 @@ int CvCitySiteEvaluator::PlotFoundValue(CvPlot* pPlot, CvPlayer* pPlayer, YieldT
 	{
 		rtnValue += (int)rtnValue * /*15*/ GC.getBUILD_ON_RIVER_PERCENT() / 100;
 	}
+
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+	if (MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY && pPlot->isMountain() && pPlayer->GetCanFoundMountainCity())
+	{
+		rtnValue += (int)rtnValue*3/2 + iIncaMountainCityValue * (pPlayer->GetCurrentEra() + 1);
+	}
+#endif
+
+#ifdef MOD_TRAITS_CAN_FOUND_COAST_CITY
+	if (MOD_TRAITS_CAN_FOUND_COAST_CITY && pPlot->getTerrainType() == TERRAIN_COAST && pPlayer->GetCanFoundCoastCity())
+	{
+		rtnValue += (int)rtnValue*3 + iPolyCoastCityValue * (pPlayer->GetCurrentEra() + 1);
+	}
+#endif
 
 	if (pPlot->isCoastalLand(GC.getMIN_WATER_SIZE_FOR_OCEAN()))
 	{

--- a/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTechClasses.cpp
@@ -2180,10 +2180,10 @@ void CvTeamTechs::SetResearchProgressTimes100(TechTypes eIndex, int iNewValue, P
 				// iNewValue = iPlayerBeakersThisTurn + ((iPlayerOverflow * iPlayerOverflowDivisorTimes100) / 100)
 				if (iOverflow > iPlayerOverflow) {
 					// If we completed the tech using only iBeakersThisTurn, we need to hand back the remaining iPlayerBeakersThisTurn and the scaled down iPlayerOverflow
-					iOverflow = (iOverflow - iPlayerOverflow) + (iPlayerOverflow * 100 / iPlayerOverflowDivisorTimes100); 
+					iOverflow = (iOverflow - iPlayerOverflow) + (iPlayerOverflow / iPlayerOverflowDivisorTimes100) * 100; 
 				} else {
 					// Otherwise we used all of iBeakersThisTurn and some of iPlayerOverflow, so we need to hand back the scaled down iOverflow
-					iOverflow = iOverflow * 100 / iPlayerOverflowDivisorTimes100;
+					iOverflow = iOverflow / iPlayerOverflowDivisorTimes100 * 100;
 				}
 			}
 #endif

--- a/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTradeClasses.cpp
@@ -335,7 +335,8 @@ bool CvGameTrade::CreateTradeRoute(CvCity* pOriginCity, CvCity* pDestCity, Domai
 	CvAStarNode* pPathfinderNode = NULL;
 	if (eDomain == DOMAIN_SEA)
 	{
-		if (pOriginCity->isCoastal(0) && pDestCity->isCoastal(0))	// Both must be on the coast (a lake is ok)  A better check would be to see if they are adjacent to the same water body.
+		// Both must be on the coast (a lake is ok)  A better check would be to see if they are adjacent to the same water body.
+		if((pOriginCity->isCoastal(0) || pOriginCity->plot()->isWater()) && (pDestCity->isCoastal(0) || pDestCity->plot()->isWater()))	
 		{
 			bSuccess = GC.GetInternationalTradeRouteWaterFinder().GeneratePath(iOriginX, iOriginY, iDestX, iDestY, eOriginPlayer, false);
 			pPathfinderNode = GC.GetInternationalTradeRouteWaterFinder().GetLastNode();
@@ -496,7 +497,8 @@ bool CvGameTrade::IsValidTradeRoutePath (CvCity* pOriginCity, CvCity* pDestCity,
 	CvAStarNode* pPathfinderNode = NULL;
 	if (eDomain == DOMAIN_SEA)
 	{
-		if (pOriginCity->isCoastal(0) && pDestCity->isCoastal(0))	// Both must be on the coast (a lake is ok)  A better check would be to see if they are adjacent to the same water body.
+		// Both must be on the coast (a lake is ok)  A better check would be to see if they are adjacent to the same water body.
+		if((pOriginCity->isCoastal(0) || pOriginCity->plot()->isWater()) && (pDestCity->isCoastal(0) || pDestCity->plot()->isWater()))	
 		{
 			bSuccess = GC.GetInternationalTradeRouteWaterFinder().GeneratePath(iOriginX, iOriginY, iDestX, iDestY, eOriginPlayer, false);
 			pPathfinderNode = GC.GetInternationalTradeRouteWaterFinder().GetLastNode();

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -7119,7 +7119,7 @@ bool CvUnit::canChangeTradeUnitHomeCityAt(const CvPlot* pPlot, int iX, int iY) c
 #if defined(MOD_BUGFIX_MINOR)
 		// The path finder permits routes between cities on lakes,
 		// so we'd better allow cargo ships to be relocated there!
-		if (!pToCity->isCoastal(0))
+		if (!pToCity->isCoastal(0) && !pToPlot->isWater())
 #else
 		if (!pToCity->isCoastal())
 #endif

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -6188,7 +6188,18 @@ void CvUnit::DoAttrition()
 		{
 			strAppendText =  GetLocalizedText("TXT_KEY_MISC_YOU_UNIT_WAS_DAMAGED_ATTRITION");
 #if defined(MOD_API_UNIT_STATS)
+	#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+			if (MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY && AI_getUnitAIType() == UNITAI_SETTLE && GET_MY_PLAYER().GetCanFoundMountainCity())
+			{
+				// Do nothing, Inca's Settle should not get mountains damage taken at the end of the turn
+			}
+			else
+			{
+				changeDamage(50, NO_PLAYER, -1, 0.0, &strAppendText);
+			}		
+	#else
 			changeDamage(50, NO_PLAYER, -1, 0.0, &strAppendText);
+	#endif
 #else
 			changeDamage(50, NO_PLAYER, 0.0, &strAppendText);
 #endif

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.cpp
@@ -1050,6 +1050,7 @@ void CvLuaPlayer::PushMethods(lua_State* L, int t)
 
 	Method(GetTraitGoldenAgeCombatModifier);
 	Method(GetTraitCityStateCombatModifier);
+	Method(GetTraitCityStateFriendshipModifier);
 	Method(GetTraitGreatGeneralExtraBonus);
 	Method(GetTraitGreatScientistRateModifier);
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_TRAITS_ANY_BELIEF)
@@ -10043,6 +10044,16 @@ int CvLuaPlayer::lGetTraitCityStateCombatModifier(lua_State* L)
 	if(pkPlayer)
 	{
 		lua_pushinteger(L, pkPlayer->GetPlayerTraits()->GetCityStateCombatModifier());
+	}
+	return 1;
+}
+//------------------------------------------------------------------------------
+int CvLuaPlayer::lGetTraitCityStateFriendshipModifier(lua_State* L)
+{
+	CvPlayer* pkPlayer = GetInstance(L);
+	if(pkPlayer)
+	{
+		lua_pushinteger(L, pkPlayer->GetStrengthModifierFromAlly());
 	}
 	return 1;
 }

--- a/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
+++ b/CvGameCoreDLL_Expansion2/Lua/CvLuaPlayer.h
@@ -966,6 +966,7 @@ protected:
 	static int lHasReceivedNetTurnComplete(lua_State* L);
 	static int lGetTraitGoldenAgeCombatModifier(lua_State* L);
 	static int lGetTraitCityStateCombatModifier(lua_State* L);
+	static int lGetTraitCityStateFriendshipModifier(lua_State* L);
 	static int lGetTraitGreatGeneralExtraBonus(lua_State* L);
 	static int lGetTraitGreatScientistRateModifier(lua_State* L);
 #if defined(MOD_API_LUA_EXTENSIONS) && defined(MOD_TRAITS_ANY_BELIEF)


### PR DESCRIPTION
调高了印加和波利建立特殊城市的倾向(总体仍然不太高)
印加的移民不会受到来自山脉的伤害
浅海城市商船转场修复