### PR TITLE
embark bugfix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -719,7 +719,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 		{
 			setHasPromotion(ePromotionEmbarkation, true);
 #ifdef MOD_TRAITS_CAN_FOUND_COAST_CITY
-			if (bIsWaterCity)
+			if (bIsWaterCity && ((!canMoveAllTerrain() && !canMoveImpassable()) || !IsCombatUnit()))
 				embark(plot());
 #endif // MOD_TRAITS_CAN_FOUND_COAST_CITY 
 		}
@@ -11332,6 +11332,8 @@ bool CvUnit::CanUpgradeRightNow(bool bOnlyTestVisible) const
 	VALIDATE_OBJECT
 	// Is Unit in a state where it can upgrade?
 	if(!isReadyForUpgrade())
+		return false;
+	if(isEmbarked())
 		return false;
 
 	UnitTypes eUpgradeUnitType = GetUpgradeUnitType();

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -719,7 +719,7 @@ void CvUnit::initWithNameOffset(int iID, UnitTypes eUnit, int iNameOffset, UnitA
 		{
 			setHasPromotion(ePromotionEmbarkation, true);
 #ifdef MOD_TRAITS_CAN_FOUND_COAST_CITY
-			if (bIsWaterCity && ((!canMoveAllTerrain() && !canMoveImpassable()) || !IsCombatUnit()))
+			if (bIsWaterCity && !canMoveAllTerrain()&& !isTrade() && (!canMoveImpassable() || !IsCombatUnit()))
 				embark(plot());
 #endif // MOD_TRAITS_CAN_FOUND_COAST_CITY 
 		}


### PR DESCRIPTION
禁止海运状态升级
波利的海城在造出悬空单位和强权里面无视所有地形的单位的时候不会强制海运