### PR TITLE
add:HolyCityPressureModifier and HolyCityUnitExperence

### DIFF
--- a/(1) CIV5MPDLL/CustomModOptions.xml
+++ b/(1) CIV5MPDLL/CustomModOptions.xml
@@ -909,7 +909,7 @@
     <Row Class="1" Name="BUGFIX_NAVAL_FREE_UNITS" Value="1"/>
     <!-- Fixes the bug where the naval units jump to the nearest city and not the nearest available non-lake water plot (v19) -->
     <!-- See also: "Global - Naval Nearest Water" -->
-    <Row Class="1" Name="BUGFIX_NAVAL_NEAREST_WATER" Value="0"/>
+    <Row Class="1" Name="BUGFIX_NAVAL_NEAREST_WATER" Value="1"/>
     <!-- Fixes the bug where naval units in hill cities attack from the top of the hill, not the harbour (v95) -->
     <Row Class="1" Name="BUGFIX_NAVAL_TARGETING" Value="1"/>
     <!-- Fixes the bug where stacked ranged units may attack out of cities but melee units may not (v19) -->

--- a/(1) CIV5MPDLL/DB/RELIGION/Belief_Table_Changes.sql
+++ b/(1) CIV5MPDLL/DB/RELIGION/Belief_Table_Changes.sql
@@ -7,3 +7,4 @@ CREATE TABLE Belief_YieldPerBirth (
 ALTER TABLE Beliefs ADD COLUMN 'AllowYieldPerBirth' BOOLEAN DEFAULT 0;
 ALTER TABLE Beliefs ADD COLUMN 'CityExtraMissionarySpreads' INTEGER DEFAULT 0;
 ALTER TABLE Beliefs ADD COLUMN 'HolyCityPressureModifier' INTEGER DEFAULT 0;
+ALTER TABLE Beliefs ADD COLUMN 'HolyCityUnitExperence' INTEGER DEFAULT 0;

--- a/(1) CIV5MPDLL/DB/RELIGION/Belief_Table_Changes.sql
+++ b/(1) CIV5MPDLL/DB/RELIGION/Belief_Table_Changes.sql
@@ -6,3 +6,4 @@ CREATE TABLE Belief_YieldPerBirth (
 
 ALTER TABLE Beliefs ADD COLUMN 'AllowYieldPerBirth' BOOLEAN DEFAULT 0;
 ALTER TABLE Beliefs ADD COLUMN 'CityExtraMissionarySpreads' INTEGER DEFAULT 0;
+ALTER TABLE Beliefs ADD COLUMN 'HolyCityPressureModifier' INTEGER DEFAULT 0;

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -58,6 +58,7 @@ CvBeliefEntry::CvBeliefEntry() :
 	m_iInquisitorPressureRetention(0),
 	m_iFaithBuildingTourism(0),
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	m_iHolyCityPressureModifier(0),
 	m_iCityExtraMissionarySpreads(0),
 	m_bAllowYieldPerBirth(false),
 	m_piYieldPerBirth(NULL),
@@ -672,6 +673,11 @@ int CvBeliefEntry::GetPlotYieldChange(int i, int j) const
 }
 #endif
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+//Extra HolyCity Religious Pressure
+int CvBeliefEntry::GetHolyCityPressureModifier() const
+{
+	return m_iHolyCityPressureModifier;
+}
 //Extra Missionary Spreads
 int CvBeliefEntry::GetCityExtraMissionarySpreads() const
 {
@@ -811,6 +817,7 @@ bool CvBeliefEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	m_iFaithBuildingTourism           = kResults.GetInt("FaithBuildingTourism");
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
 	m_iCityExtraMissionarySpreads	  = kResults.GetInt("CityExtraMissionarySpreads");
+	m_iHolyCityPressureModifier	  	  = kResults.GetInt("HolyCityPressureModifier");
 #endif
 
 	m_bPantheon						  = kResults.GetBool("Pantheon");
@@ -2060,6 +2067,22 @@ int CvReligionBeliefs::GetPlotYieldChange(PlotTypes ePlot, YieldTypes eYieldType
 #endif
 
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+//Is has Extra HolyCity Religious Pressure ?
+int CvReligionBeliefs::GetHolyCityPressureModifier() const
+{
+	CvBeliefXMLEntries* pBeliefs = GC.GetGameBeliefs();
+	int rtnValue = 0;
+
+	for(int i = 0; i < pBeliefs->GetNumBeliefs(); i++)
+	{
+		if(HasBelief((BeliefTypes)i))
+		{
+			rtnValue += pBeliefs->GetEntry(i)->GetHolyCityPressureModifier();
+		}
+	}
+
+	return rtnValue;
+}
 //Is has Extra Missionary Spreads ?
 int CvReligionBeliefs::GetCityExtraMissionarySpreads() const
 {

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -58,6 +58,7 @@ CvBeliefEntry::CvBeliefEntry() :
 	m_iInquisitorPressureRetention(0),
 	m_iFaithBuildingTourism(0),
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	m_iHolyCityUnitExperence(0),
 	m_iHolyCityPressureModifier(0),
 	m_iCityExtraMissionarySpreads(0),
 	m_bAllowYieldPerBirth(false),
@@ -673,6 +674,11 @@ int CvBeliefEntry::GetPlotYieldChange(int i, int j) const
 }
 #endif
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+//Extra Experence for Holy City Unit
+int CvBeliefEntry::GetHolyCityUnitExperence() const
+{
+	return m_iHolyCityUnitExperence;
+}
 //Extra HolyCity Religious Pressure
 int CvBeliefEntry::GetHolyCityPressureModifier() const
 {
@@ -816,6 +822,7 @@ bool CvBeliefEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 	m_iInquisitorPressureRetention    = kResults.GetInt("InquisitorPressureRetention");
 	m_iFaithBuildingTourism           = kResults.GetInt("FaithBuildingTourism");
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	m_iHolyCityUnitExperence	  	  = kResults.GetInt("HolyCityUnitExperence");
 	m_iCityExtraMissionarySpreads	  = kResults.GetInt("CityExtraMissionarySpreads");
 	m_iHolyCityPressureModifier	  	  = kResults.GetInt("HolyCityPressureModifier");
 #endif
@@ -2067,6 +2074,22 @@ int CvReligionBeliefs::GetPlotYieldChange(PlotTypes ePlot, YieldTypes eYieldType
 #endif
 
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+//Is has Extra Experence for Holy City Unit ?
+int CvReligionBeliefs::GetHolyCityUnitExperence() const
+{
+	CvBeliefXMLEntries* pBeliefs = GC.GetGameBeliefs();
+	int rtnValue = 0;
+
+	for(int i = 0; i < pBeliefs->GetNumBeliefs(); i++)
+	{
+		if(HasBelief((BeliefTypes)i))
+		{
+			rtnValue += pBeliefs->GetEntry(i)->GetHolyCityUnitExperence();
+		}
+	}
+
+	return rtnValue;
+}
 //Is has Extra HolyCity Religious Pressure ?
 int CvReligionBeliefs::GetHolyCityPressureModifier() const
 {

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -123,6 +123,7 @@ public:
 	int GetPlotYieldChange(int i, int j) const;
 #endif
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	int GetHolyCityUnitExperence() const;
 	int GetHolyCityPressureModifier() const;
 	int GetCityExtraMissionarySpreads() const;
 	bool AllowYieldPerBirth() const;
@@ -182,6 +183,7 @@ protected:
 	int m_iInquisitorPressureRetention;
 	int m_iFaithBuildingTourism;
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	int m_iHolyCityUnitExperence;
 	int m_iHolyCityPressureModifier;
 	int m_iCityExtraMissionarySpreads;
 	bool m_bAllowYieldPerBirth;
@@ -462,6 +464,7 @@ public:
 	int GetPlotYieldChange(PlotTypes ePlot, YieldTypes eYieldType) const;
 #endif
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	int GetHolyCityUnitExperence() const;
 	int GetHolyCityPressureModifier() const;
 	int GetCityExtraMissionarySpreads() const;
 	bool AllowYieldPerBirth() const;

--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.h
@@ -123,6 +123,7 @@ public:
 	int GetPlotYieldChange(int i, int j) const;
 #endif
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	int GetHolyCityPressureModifier() const;
 	int GetCityExtraMissionarySpreads() const;
 	bool AllowYieldPerBirth() const;
 	int GetYieldPerBirth(int i) const;
@@ -181,6 +182,7 @@ protected:
 	int m_iInquisitorPressureRetention;
 	int m_iFaithBuildingTourism;
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	int m_iHolyCityPressureModifier;
 	int m_iCityExtraMissionarySpreads;
 	bool m_bAllowYieldPerBirth;
 	int* m_piYieldPerBirth;
@@ -460,6 +462,7 @@ public:
 	int GetPlotYieldChange(PlotTypes ePlot, YieldTypes eYieldType) const;
 #endif
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+	int GetHolyCityPressureModifier() const;
 	int GetCityExtraMissionarySpreads() const;
 	bool AllowYieldPerBirth() const;
 	int GetYieldPerBirth(YieldTypes eYieldType) const;

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -4278,6 +4278,18 @@ int CvCity::getProductionExperience(UnitTypes eUnit)
 			}
 
 			iExperience += getSpecialistFreeExperience();
+#if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+			//Experence from Religion
+			ReligionTypes eCityReligion = GetCityReligions()->GetReligiousMajority();
+			if(MOD_BELIEF_NEW_EFFECT_FOR_SP && eCityReligion != NO_RELIGION)
+			{
+				int iExBouns = GC.getGame().GetGameReligions()->GetReligion(eCityReligion,getOwner())->m_Beliefs.GetHolyCityUnitExperence();
+				if(iExBouns != 0 && GetCityReligions()->IsHolyCityForReligion(eCityReligion) && GET_PLAYER(getOwner()).HasReligion(eCityReligion))
+				{
+					iExperience += iExBouns;
+				}
+			}
+#endif
 		}
 	}
 

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -6645,9 +6645,9 @@ int CvReligionAI::ScoreBeliefForPlayer(CvBeliefEntry* pEntry)
 	}
 
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
-	//Is has Extra Missionary Spreads ?
 	iRtnValue += pEntry->GetCityExtraMissionarySpreads() * iFlavorReligon;
-	iRtnValue += pEntry->GetHolyCityPressureModifier() /10 * iFlavorReligon;
+	iRtnValue += pEntry->GetHolyCityPressureModifier() / 10 * iFlavorReligon;
+	iRtnValue += pEntry->GetHolyCityUnitExperence() * (iFlavorDefense + iFlavorOffense) / 2;
 #endif
 
 	//----------------

--- a/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -2449,6 +2449,16 @@ int CvGameReligions::GetAdjacentCityReligiousPressure (ReligionTypes eReligion, 
 			iPressure *= (100 + iModifier);
 			iPressure /= 100;
 		}
+
+#if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
+		// Belief that boosts pressure from originating city?
+		int iHolyCityModifier = GC.getGame().GetGameReligions()->GetReligion(eReligion,pFromCity->getOwner())->m_Beliefs.GetHolyCityPressureModifier();
+		if(MOD_BELIEF_NEW_EFFECT_FOR_SP && iHolyCityModifier !=0 && pFromCity->GetCityReligions()->IsHolyCityForReligion(eReligion))
+		{
+			iPressure *= (100 + iHolyCityModifier);
+			iPressure /=100;
+		}
+#endif		
 	}
 
 #if defined(MOD_RELIGION_CONVERSION_MODIFIERS)
@@ -6637,6 +6647,7 @@ int CvReligionAI::ScoreBeliefForPlayer(CvBeliefEntry* pEntry)
 #if defined(MOD_BELIEF_NEW_EFFECT_FOR_SP)
 	//Is has Extra Missionary Spreads ?
 	iRtnValue += pEntry->GetCityExtraMissionarySpreads() * iFlavorReligon;
+	iRtnValue += pEntry->GetHolyCityPressureModifier() /10 * iFlavorReligon;
 #endif
 
 	//----------------


### PR DESCRIPTION
1.增加了信条给圣城增加本地单位经验的接口
2.增加了信条给圣城增加宗教压力的接口，和建筑加成乘算
3.开启了BUGFIX_NAVAL_NEAREST_WATER，海军解放城市后不会传送到远处城市而是移到城市旁边