### PR TITLE
bugfix and close some event in default

### DIFF
--- a/(1) CIV5MPDLL/CustomModOptions.xml
+++ b/(1) CIV5MPDLL/CustomModOptions.xml
@@ -982,17 +982,17 @@
 
     <Row Class="2" Name="ROG_CORE" Value="1"/>
 
-    <Row Class="4" Name="MORE_NATURAL_WONDER" Value="1"/>
+    <Row Class="4" Name="MORE_NATURAL_WONDER" Value="0"/>
 
-    <Row Class="3"  Name="EVENTS_UNIT_CAN_RANGEATTACK" Value="1"/>
+    <Row Class="3"  Name="EVENTS_UNIT_CAN_RANGEATTACK" Value="0"/>
     <!--GameEvents.UnitCanRangeAttackPlot.Add(function(iPlayer, iUnit, iPlotX, iPlotY, bNeedWar) return true end)-->
-    <Row Class="3"  Name="EVENTS_UNIT_DO_TURN" Value="1"/>
+    <Row Class="3"  Name="EVENTS_UNIT_DO_TURN" Value="0"/>
     <!-- GameEvents.UnitDoTurn.Add(function(iPlayer, iUnit, iPlotX, iPlotY) end)-->
     <Row Class="3"  Name="EVENTS_UNIT_MOVE" Value="0"/>
     <!--GameEvents.UnitMoveInto.Add(function(iPlayer, iUnit, iUsedMoves, iOldPlotX, iOldPlotY,iNewPlotX, iNewPlotY) end)-->
-    <Row Class="3" Name="EVENTS_GREAT_WORK_CREATED" Value="1"/>
+    <Row Class="3" Name="EVENTS_GREAT_WORK_CREATED" Value="0"/>
     <!--GameEvents.GreatWorkCreated.Add(function(iPlayer, iUnit, iGreatWork) end)--> 
-    <Row Class="3" Name="EVENTS_GREAT_PEOPLE_BOOST" Value="1"/> 
+    <Row Class="3" Name="EVENTS_GREAT_PEOPLE_BOOST" Value="0"/> 
     <!--GameEvents.ScienceDiscover.Add(function(iPlayer,iUnit,iX,iY,bIsGreatPerson) end)-->   
     <!--GameEvents.CultureDiscover.Add(function(iPlayer, iUnit, iX, iY, bIsGreatPerson) end)-->   
     <!--GameEvents.TourismDiscover.Add(function(iPlayer, iUnit, iX, iY, bIsGreatPerson) end)-->   
@@ -1001,16 +1001,16 @@
     <!--GameEvents.GoldenAgeDiscover.Add(function(iPlayer, iUnit, iX, iY, bIsGreatPerson) end)-->  
     <!--GameEvents.CultureBombDiscover.Add(function(iPlayer, iUnit, iX, iY, bIsGreatPerson) end)-->  
     <!--GameEvents.FaithDiscover.Add(function(iPlayer, iUnit, iX, iY, bIsGreatPerson) end)-->  
-    <Row Class="3" Name="EVENTS_CITY_PUPPETED" Value="1"/>
+    <Row Class="3" Name="EVENTS_CITY_PUPPETED" Value="0"/>
     <!--GameEvents.CityPuppeted.Add(function(playerID, cityID) end)--> 
-    <Row Class="3" Name="EVENTS_CITY_RANGE_STRIKE" Value="1"/>
+    <Row Class="3" Name="EVENTS_CITY_RANGE_STRIKE" Value="0"/>
     <!--GameEvents.CityRangedStrike.Add(function(iPlayer,iAttCity,idefPlayer,idefUnit,iX, iY) end)--> 
-    <Row Class="3" Name="EVENTS_TILE_SET_OWNER" Value="1"/>
+    <Row Class="3" Name="EVENTS_TILE_SET_OWNER" Value="0"/>
     <!--GameEvents.TileSetOwnership.Add(iPlotX, iPlotY, iOldOwner,iNewOwner) end)--> 
-    <Row Class="3" Name="EVENTS_WLKD_DAY" Value="1"/>
+    <Row Class="3" Name="EVENTS_WLKD_DAY" Value="0"/>
     <!--GameEvents.CityBeginsWLTKD.Add(iPlayer, iPlotX, iPlotY, iChange) end)--> 
     <!--GameEvents.CityEndsWLTKD.Add(iPlayer, iPlotX, iPlotY) end)--> 
-    <Row Class="3" Name="EVENTS_IMPROVEMENTS_PILLAGED" Value="1"/>  
+    <Row Class="3" Name="EVENTS_IMPROVEMENTS_PILLAGED" Value="0"/>  
     <!--GameEvents.TileImprovementPillaged.Add(iPlotX, iPlotY, iOwner,iImprovement,bPillaged) end)-->
 
     <!-- GameEvents.GetImprovementXPPerTurn.Add(function(iX, iY, iImprovementType, iCurrentXP, iOwner, iWorkCity) return 0 end); // notice: the iOnwer or iWorkCity may be -1 -->

--- a/(1) CIV5MPDLL/CustomModOptions.xml
+++ b/(1) CIV5MPDLL/CustomModOptions.xml
@@ -982,7 +982,7 @@
 
     <Row Class="2" Name="ROG_CORE" Value="1"/>
 
-<Row Class="4" Name="MORE_NATURAL_WONDER" Value="1"/>
+    <Row Class="4" Name="MORE_NATURAL_WONDER" Value="1"/>
 
     <Row Class="3"  Name="EVENTS_UNIT_CAN_RANGEATTACK" Value="1"/>
     <!--GameEvents.UnitCanRangeAttackPlot.Add(function(iPlayer, iUnit, iPlotX, iPlotY, bNeedWar) return true end)-->

--- a/(1) CIV5MPDLL/DB/NewTableChanges.sql
+++ b/(1) CIV5MPDLL/DB/NewTableChanges.sql
@@ -136,7 +136,4 @@ ALTER TABLE UnitPromotions ADD 'CannotBeCaptured' BOOLEAN DEFAULT 0;
 
 ALTER TABLE Policies ADD 'WaterBuildSpeedModifier' INTEGER DEFAULT 0;
 
-
-ALTER TABLE Features ADD COLUMN 'FreePromotionIfOwned' TEXT DEFAULT NULL;
-
 ALTER TABLE Features ADD PseudoNaturalWonder INTEGER DEFAULT 0;

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -866,7 +866,11 @@ int PathDestValid(int iToX, int iToY, const void* pointer, CvAStar* finder)
 		return TRUE;
 	}
 
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+	if(pToPlot->isMountain() && !pToPlot->isCity() && !pUnit->canFound(pToPlot) && (!pCacheData->isHuman() || pCacheData->IsAutomated()))
+#else 
 	if(pToPlot->isMountain() && !pToPlot->isCity() && (!pCacheData->isHuman() || pCacheData->IsAutomated()))
+#endif
 	{
 		return FALSE;
 	}
@@ -1098,11 +1102,10 @@ int PathCost(CvAStarNode* parent, CvAStarNode* node, int data, const void* point
 			if (!pCacheData->isHuman() || pCacheData->IsAutomated())
 			{
 #ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
-				if (pUnit->canFound(pToPlot))
+				if (MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY && !pUnit->canFound(pToPlot))
 				{
-					iCost += GC.getINFLUENCE_HILL_COST();
+					iCost += PATH_END_TURN_MOUNTAIN_WEIGHT;
 				}
-				else iCost += PATH_END_TURN_MOUNTAIN_WEIGHT;
 #else
 				iCost += PATH_END_TURN_MOUNTAIN_WEIGHT;
 #endif
@@ -1351,7 +1354,7 @@ int PathValid(CvAStarNode* parent, CvAStarNode* node, int data, const void* poin
 						}
 
 #ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
-						if (kNodeCacheData.bIsMountain && !kNodeCacheData.bIsCity && !(iFinderIgnoreStacking) && (!bIsHuman || bAIControl))
+						if (kNodeCacheData.bIsMountain && !kNodeCacheData.bIsCity && !(iFinderIgnoreStacking) && (!bIsHuman || bAIControl) && !pUnit->canFound(pToPlot))
 						{
 							return FALSE;
 						}
@@ -1682,7 +1685,11 @@ int IgnoreUnitsDestValid(int iToX, int iToY, const void* pointer, CvAStar* finde
 		return FALSE;
 	}
 
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+	if((pToPlot->isMountain() && !pToPlot->isCity() && !pUnit->canFound(pToPlot)) && (!pCacheData->isHuman() || pCacheData->IsAutomated()))
+#else
 	if((pToPlot->isMountain() && !pToPlot->isCity()) && (!pCacheData->isHuman() || pCacheData->IsAutomated()))
+#endif
 	{
 		return FALSE;
 	}

--- a/CvGameCoreDLL_Expansion2/CvAStar.cpp
+++ b/CvGameCoreDLL_Expansion2/CvAStar.cpp
@@ -1102,7 +1102,7 @@ int PathCost(CvAStarNode* parent, CvAStarNode* node, int data, const void* point
 			if (!pCacheData->isHuman() || pCacheData->IsAutomated())
 			{
 #ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
-				if (MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY && !pUnit->canFound(pToPlot))
+				if (!MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY || !pUnit->canFound(pToPlot))
 				{
 					iCost += PATH_END_TURN_MOUNTAIN_WEIGHT;
 				}

--- a/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -10449,7 +10449,10 @@ void CvCity::SetPuppet(bool bValue)
 	if(IsPuppet() != bValue)
 	{
 #if defined(MOD_EVENTS_CITY_PUPPETED)
-		GAMEEVENTINVOKE_HOOK(GAMEEVENT_CityPuppeted, getOwner(), GetID());
+		if(MOD_EVENTS_CITY_PUPPETED)
+		{
+			GAMEEVENTINVOKE_HOOK(GAMEEVENT_CityPuppeted, getOwner(), GetID());
+		}
 #endif
 		m_bPuppet = bValue;
 	}
@@ -11008,7 +11011,10 @@ void CvCity::SetWeLoveTheKingDayCounter(int iValue)
 	else if (iValue == 0)
 	{
 #if defined(MOD_EVENTS_WLKD_DAY)
-		GAMEEVENTINVOKE_HOOK(GAMEEVENT_CityEndsWLTKD, getOwner(), getX(), getY(), iValue);
+		if(MOD_EVENTS_WLKD_DAY)
+		{
+			GAMEEVENTINVOKE_HOOK(GAMEEVENT_CityEndsWLTKD, getOwner(), getX(), getY(), iValue);
+		}
 #endif
 	}
 	m_iWeLoveTheKingDayCounter = iValue;

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -5481,18 +5481,21 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 			setOwnershipDuration(0);
 
 #if defined(MOD_MORE_NATURAL_WONDER)
-			FeatureTypes eFeature = getFeatureType();
-			CvFeatureInfo* pFeatureInfo = GC.getFeatureInfo(eFeature);
-
-			if (pFeatureInfo && eNewValue != NO_PLAYER)
+			if(MOD_MORE_NATURAL_WONDER)
 			{
-	
-				PromotionTypes eFreePromotion = (PromotionTypes)pFeatureInfo->getPromotionIfOwned();
-				if (eFreePromotion != NO_PROMOTION)
+				FeatureTypes eFeature = getFeatureType();
+				CvFeatureInfo* pFeatureInfo = GC.getFeatureInfo(eFeature);
+
+				if (pFeatureInfo && eNewValue != NO_PLAYER)
 				{
-					if (!GET_PLAYER(eNewValue).IsFreePromotion(eFreePromotion))
+		
+					PromotionTypes eFreePromotion = (PromotionTypes)pFeatureInfo->getPromotionIfOwned();
+					if (eFreePromotion != NO_PROMOTION)
 					{
-						GET_PLAYER(eNewValue).ChangeFreePromotionCount(eFreePromotion, 1);
+						if (!GET_PLAYER(eNewValue).IsFreePromotion(eFreePromotion))
+						{
+							GET_PLAYER(eNewValue).ChangeFreePromotionCount(eFreePromotion, 1);
+						}
 					}
 				}
 			}

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -5481,11 +5481,10 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 			setOwnershipDuration(0);
 
 #if defined(MOD_MORE_NATURAL_WONDER)
+			FeatureTypes eFeature = getFeatureType();
+			CvFeatureInfo* pFeatureInfo = GC.getFeatureInfo(eFeature);
 			if(MOD_MORE_NATURAL_WONDER)
 			{
-				FeatureTypes eFeature = getFeatureType();
-				CvFeatureInfo* pFeatureInfo = GC.getFeatureInfo(eFeature);
-
 				if (pFeatureInfo && eNewValue != NO_PLAYER)
 				{
 		
@@ -5505,7 +5504,7 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 			if(isOwned())
 			{
 #if defined(MOD_BALANCE_CORE)
-				if (pFeatureInfo && eOldOwner != NO_PLAYER)
+				if (MOD_BALANCE_CORE && pFeatureInfo && eOldOwner != NO_PLAYER)
 				{
 
 					PromotionTypes eFreePromotion = (PromotionTypes)pFeatureInfo->getPromotionIfOwned();
@@ -5516,7 +5515,7 @@ void CvPlot::setOwner(PlayerTypes eNewValue, int iAcquiringCityID, bool bCheckUn
 							GET_PLAYER(eOldOwner).ChangeFreePromotionCount(eFreePromotion, -1);
 						}
 
-					}
+				}
 			}
 #endif
 

--- a/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvSiteEvaluationClasses.cpp
@@ -672,7 +672,7 @@ int CvCitySiteEvaluator::PlotFoundValue(CvPlot* pPlot, CvPlayer* pPlayer, YieldT
 #ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
 	if (MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY && pPlot->isMountain() && pPlayer->GetCanFoundMountainCity())
 	{
-		rtnValue += (int)rtnValue * (iIncaMountainCityValue + pPlayer->GetCurrentEra());
+		rtnValue += (int)rtnValue * (iIncaMountainCityValue + pPlayer->GetCurrentEra()) * 2;
 	}
 #endif
 

--- a/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
+++ b/CvGameCoreDLL_Expansion2/CvTacticalAI.cpp
@@ -4244,7 +4244,11 @@ void CvTacticalAI::PlotSingleHexOperationMoves(CvAIEscortedOperation* pOperation
 						// can move that escort can't -- like minor civ territory), then find a new path based on moving the escort
 						if(pCell->IsFriendlyTurnEndTile() || !pBlockingUnit)
 						{
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+							if(!pEscort->GeneratePath(pOperation->GetTargetPlot(), 0, false /*bReuse*/) && !pOperation->GetTargetPlot()->isMountain())
+#else
 							if(!pEscort->GeneratePath(pOperation->GetTargetPlot(), 0, false /*bReuse*/))
+#endif
 							{
 								pOperation->RetargetCivilian(pCivilian.pointer(), pThisArmy);
 								pCivilian->finishMoves();
@@ -4278,6 +4282,21 @@ void CvTacticalAI::PlotSingleHexOperationMoves(CvAIEscortedOperation* pOperation
 										LogTacticalMessage(strLogString);
 									}
 								}
+#ifdef MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY
+								else if(MOD_TRAITS_CAN_FOUND_MOUNTAIN_CITY && pEscortMove->isMountain())
+								{
+									ExecuteMoveToPlot(pCivilian, pEscortMove, true);
+									pEscort->finishMoves();
+									if(GC.getLogging() && GC.getAILogging())
+									{
+										CvString strLogString;
+										CvString strTemp;
+										strTemp = pCivilian->getUnitInfo().GetDescription();
+										strLogString.Format("Moving %s to target mountain, X: %d, Y: %d, Escort stand", strTemp.GetCString(), pCivilian->getX(), pCivilian->getY());
+										LogTacticalMessage(strLogString);
+									}
+								}
+#endif
 								else
 								{
 									// Didn't find an alternative, retarget operation

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -17129,18 +17129,17 @@ bool CvUnit::isInvisible(TeamTypes eTeam, bool bDebug, bool bCheckCargo) const
 		}
 	}
 
-	
+	if(m_eInvisibleType == NO_INVISIBLE)
+	{
+		return false;
+	}
+
 #if defined(MOD_PROMOTION_FEATURE_INVISIBLE)
 	if(IsInvisibleInvalid())
 	{
 		return false;
 	}
 #endif
-
-	if(m_eInvisibleType == NO_INVISIBLE)
-	{
-		return false;
-	}
 
 	return !(plot()->isInvisibleVisible(eTeam, getInvisibleType()));
 }

--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -8255,12 +8255,15 @@ bool CvUnit::createGreatWork()
 			}
 		}
 
-#if defined(MOD_EVENTS_GREAT_WORK_CREATED)
-		CvGameCulture* pCulture = GC.getGame().GetGameCulture();
-		if (pCulture != NULL)
+#if defined(EVENTS_GREAT_WORK_CREATED)
+		if(EVENTS_GREAT_WORK_CREATED)
 		{
-			int iValue = (int)eGreatWorkType;
-			GAMEEVENTINVOKE_HOOK(GAMEEVENT_GreatWorkCreated, getOwner(), GetID(), iValue);
+			CvGameCulture* pCulture = GC.getGame().GetGameCulture();
+			if (pCulture != NULL)
+			{
+				int iValue = (int)eGreatWorkType;
+				GAMEEVENTINVOKE_HOOK(GAMEEVENT_GreatWorkCreated, getOwner(), GetID(), iValue);
+			}
 		}
 #endif
 
@@ -9642,9 +9645,10 @@ bool CvUnit::DoSpreadReligion()
 			}
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+			if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 			{
 				GAMEEVENTINVOKE_HOOK(GAMEEVENT_FaithDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
-			 }
+			}
 #endif
 
 			if(IsGreatPerson())
@@ -10135,6 +10139,7 @@ bool CvUnit::discover()
 
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+	if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 	{
 		//int iBeakersBonus = getDiscoverAmount();
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_ScienceDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
@@ -10360,6 +10365,7 @@ bool CvUnit::hurry()
 
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+	if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 	{
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_ProductionDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
 	}
@@ -10492,6 +10498,7 @@ bool CvUnit::trade()
 	}
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+	if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 	{
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_GoldDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
 	}
@@ -10852,6 +10859,7 @@ bool CvUnit::DoCultureBomb()
 			gDLL->GameplayUnitActivate(pDllUnit.get());
 		}
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+		if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 		{
 			GAMEEVENTINVOKE_HOOK(GAMEEVENT_CultureBombDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
 		}
@@ -11058,6 +11066,7 @@ bool CvUnit::goldenAge()
 	}
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+	if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 	{
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_GoldenAgeDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
 	}
@@ -11204,6 +11213,7 @@ bool CvUnit::givePolicies()
 
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+	if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 	{
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_CultureDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
 	}
@@ -11315,6 +11325,7 @@ bool CvUnit::blastTourism()
 	}
 
 #if defined(MOD_EVENTS_GREAT_PEOPLE_BOOST)
+	if(MOD_EVENTS_GREAT_PEOPLE_BOOST)
 	{
 		GAMEEVENTINVOKE_HOOK(GAMEEVENT_TourismDiscover, getOwner(), GetID(), getX(), getY(), IsGreatPerson());
 	}

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -5164,6 +5164,7 @@ void CvUnitCombat::DoHeavyChargeEffects(CvUnit* attacker, CvUnit* defender, CvPl
 void CvUnitCombat::DoBounsFromCombatDamage(const CvCombatInfo & kCombatInfo)
 {
 	if (!MOD_PROMOTION_NEW_EFFECT_FOR_SP) return;
+	if (!ShouldDoNewBattleEffects(kCombatInfo)) return;
 	CvUnit* pAttackerUnit = kCombatInfo.getUnit(BATTLE_UNIT_ATTACKER);
 	CvUnit* pDefenderUnit = kCombatInfo.getUnit(BATTLE_UNIT_DEFENDER);
 	// Only work when unit vs unit

--- a/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnitCombat.cpp
@@ -1354,7 +1354,7 @@ void CvUnitCombat::ResolveCityMeleeCombat(const CvCombatInfo& kCombatInfo, uint 
 	{
 #if defined(MOD_PROMOTION_NEW_EFFECT_FOR_SP)
 		DoBounsFromCombatDamage(kCombatInfo);
-		if(pkAttacker->GetLostAllMovesAttackCity() > 0)
+		if(MOD_PROMOTION_NEW_EFFECT_FOR_SP && pkAttacker->GetLostAllMovesAttackCity() > 0)
 		{
 			pkAttacker->setMoves(0);
 			if (pkAttacker->getOwner() == GC.getGame().getActivePlayer())


### PR DESCRIPTION
1.修复印加坐城目标为山城时移民卡住不动的问题
2.给部分lua接口增加了判定并默认关闭了强权的一些事件（这些事件在强权都有UPDATE语句）
3.删除了一个重复插入的FreePromotionIfOwned
4.将地貌隐形的一段代码的判定移后了一些