### PR TITLE
fix: AdjacentMountainYieldChange

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
+++ b/CvGameCoreDLL_Expansion2/CvBeliefClasses.cpp
@@ -1524,7 +1524,8 @@ int CvReligionBeliefs:: GetWonderProductionModifier(EraTypes eWonderEra) const
 	for (BeliefList::const_iterator i = m_ReligionBeliefs.begin(); i != m_ReligionBeliefs.end(); i++)
 	{
 		CvBeliefEntry* pBeliefEntry = pBeliefs->GetEntry(*i);
-		if((int)eWonderEra < (int)pBeliefEntry->GetObsoleteEra())
+		int iObsoleteEra = pBeliefEntry->GetObsoleteEra();
+		if((iObsoleteEra != NO_ERA && (int)eWonderEra < iObsoleteEra) || iObsoleteEra == NO_ERA)
 		{
 			rtnValue += pBeliefEntry->GetWonderProductionModifier();
 		}

--- a/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -8830,7 +8830,7 @@ int CvPlot::calculateImprovementYieldChange(ImprovementTypes eImprovement, Yield
 						iYield += pImprovement->GetAdjacentCityYieldChange(eYield);
 					}
 				}
-				else if(pAdjacentPlot->isMountain())
+				if(pAdjacentPlot->isMountain())
 				{
 					iYield += pImprovement->GetAdjacentMountainYieldChange(eYield);
 				}


### PR DESCRIPTION
1.修复梯田不能受到山脉城市加成的问题
2.信条的奇观速率加成可以在不指定时代的前提下生效