### PR TITLE
Fix incorrect variable init in unit XP

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -2906,12 +2906,13 @@ void CvUnit::doTurn()
 		}
 		if(!IsCivilianUnit() && pPlot)
 		{
-			CvCity* pCity = pPlot->getPlotCity();
-			if (pCity)
-			{
-				int itempexp = itempexp = pCity->GetDomainFreeExperiencesPerTurn(getDomainType());
-				if (itempexp > 0) iTotalxp += itempexp;
-			}
+                       CvCity* pCity = pPlot->getPlotCity();
+                       if (pCity)
+                       {
+                               int itempexp = pCity->GetDomainFreeExperiencesPerTurn(getDomainType());
+                               if (itempexp > 0)
+                                       iTotalxp += itempexp;
+                       }
 			iTotalxp += GET_PLAYER(getOwner()).GetDomainFreeExperiencesPerTurnGlobal(getDomainType());
 			iTotalxp += GetFreeExpPerTurn();
 		}


### PR DESCRIPTION
## Summary
- fix initialization for city XP per turn when unit is stationed in a city

## Testing
- `make -n` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6847dbd760a4832eb71f70d438eea938